### PR TITLE
fix: require bucket argument for ls command

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -10,8 +10,22 @@ import (
 
 // lsCmd represents the ls command
 var lsCmd = &cobra.Command{
-	Use:   "ls",
-	Short: "List either all buckets or all objects in a bucket",
+	Use:   "ls [bucket-name]",
+	Short: "List objects in a bucket",
+	Long: `List objects in an R2 bucket.
+
+To list objects in a bucket, provide the bucket name as an argument.
+
+Examples:
+  # List all objects in a bucket
+  r2 ls example-bucket
+
+  # List objects in multiple buckets
+  r2 ls bucket1 bucket2
+
+  # List objects using R2 URI format
+  r2 ls r2://example-bucket`,
+	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get profile client
 		profileName, err := cmd.Flags().GetString("profile")
@@ -20,18 +34,13 @@ var lsCmd = &cobra.Command{
 		}
 		c := pkg.Client(getProfile(profileName))
 
-		if len(args) > 0 {
-			// If args passed to ls, list objects in each bucket passed
-			for _, bucketName := range args {
-				// Remove URI scheme if present
-				bucketName = pkg.RemoveR2URIPrefix(bucketName)
+		// List objects in each bucket passed
+		for _, bucketName := range args {
+			// Remove URI scheme if present
+			bucketName = pkg.RemoveR2URIPrefix(bucketName)
 
-				b := c.Bucket(bucketName)
-				b.PrintObjects()
-			}
-		} else {
-			// If no args passed to ls, list all buckets
-			c.PrintBuckets()
+			b := c.Bucket(bucketName)
+			b.PrintObjects()
 		}
 	},
 }


### PR DESCRIPTION
## Summary
- Fixed the `ls` command to require at least one bucket name argument
- Shows helpful usage information instead of access denied errors when run without arguments
- Added comprehensive documentation with usage examples

## Test plan
- [x] Running `./r2 ls` without arguments shows usage message
- [x] Running `./r2 ls example-bucket` lists objects in the bucket
- [x] Running `./r2 ls --help` displays comprehensive help with examples
- [x] R2 URI format `./r2 ls r2://example-bucket` still works
- [x] Multiple buckets can be listed: `./r2 ls bucket1 bucket2`

Fixes #2