### PR TITLE
Fix sync command authentication errors and add subdirectory support

### DIFF
--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -27,18 +27,18 @@ var cpCmd = &cobra.Command{
 			destinationPath := args[1]
 			if !pkg.IsR2URI(sourcePath) && pkg.IsR2URI(destinationPath) {
 				// Copy local file to R2
-				destURI := pkg.ParseR2URI(destinationPath)
+				destURI := pkg.ParseR2URISafe(destinationPath)
 				b := c.Bucket(destURI.Bucket)
 				b.Upload(sourcePath, destURI.Path)
 			} else if pkg.IsR2URI(sourcePath) && !pkg.IsR2URI(destinationPath) {
 				// Copy R2 object to local file
-				sourceURI := pkg.ParseR2URI(sourcePath)
+				sourceURI := pkg.ParseR2URISafe(sourcePath)
 				b := c.Bucket(sourceURI.Bucket)
 				b.Download(sourceURI.Path, destinationPath)
 			} else if pkg.IsR2URI(sourcePath) && pkg.IsR2URI(destinationPath) {
 				// Copy R2 object to R2 object
-				sourceURI := pkg.ParseR2URI(sourcePath)
-				destURI := pkg.ParseR2URI(destinationPath)
+				sourceURI := pkg.ParseR2URISafe(sourcePath)
+				destURI := pkg.ParseR2URISafe(destinationPath)
 				b := c.Bucket(sourceURI.Bucket)
 				b.Copy(sourceURI.Path, destURI)
 			}

--- a/cmd/mv.go
+++ b/cmd/mv.go
@@ -28,20 +28,20 @@ var mvCmd = &cobra.Command{
 			destinationPath := args[1]
 			if !pkg.IsR2URI(sourcePath) && pkg.IsR2URI(destinationPath) {
 				// Move local file to R2
-				destURI := pkg.ParseR2URI(destinationPath)
+				destURI := pkg.ParseR2URISafe(destinationPath)
 				b := c.Bucket(destURI.Bucket)
 				b.Upload(sourcePath, destURI.Path)
 				os.Remove(sourcePath)
 			} else if pkg.IsR2URI(sourcePath) && !pkg.IsR2URI(destinationPath) {
 				// Move R2 object to local file
-				sourceURI := pkg.ParseR2URI(sourcePath)
+				sourceURI := pkg.ParseR2URISafe(sourcePath)
 				b := c.Bucket(sourceURI.Bucket)
 				b.Download(sourceURI.Path, destinationPath)
 				b.Delete(sourceURI.Path)
 			} else if pkg.IsR2URI(sourcePath) && pkg.IsR2URI(destinationPath) {
 				// Move R2 object to R2 object
-				sourceURI := pkg.ParseR2URI(sourcePath)
-				destURI := pkg.ParseR2URI(destinationPath)
+				sourceURI := pkg.ParseR2URISafe(sourcePath)
+				destURI := pkg.ParseR2URISafe(destinationPath)
 				b := c.Bucket(sourceURI.Bucket)
 				b.Copy(sourceURI.Path, destURI)
 				b.Delete(sourceURI.Path)

--- a/cmd/presign.go
+++ b/cmd/presign.go
@@ -25,7 +25,7 @@ var presignCmd = &cobra.Command{
 
 		for _, arg := range args {
 			// Get R2 URI components from argument
-			uri := pkg.ParseR2URI(arg)
+			uri := pkg.ParseR2URISafe(arg)
 
 			// If object exists in bucket, print presigned URL to get object from bucket, otherwise print
 			// presigned URL to put object in bucket

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -24,7 +24,7 @@ var rmCmd = &cobra.Command{
 		// If a bucket name is provided, create the bucket
 		for _, arg := range args {
 			if pkg.IsR2URI(arg) {
-				uri := pkg.ParseR2URI(arg)
+				uri := pkg.ParseR2URISafe(arg)
 				b := c.Bucket(uri.Bucket)
 				b.Delete(uri.Path)
 			} else {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -27,17 +27,24 @@ var syncCmd = &cobra.Command{
 			destinationPath := args[1]
 			if !pkg.IsR2URI(sourcePath) && pkg.IsR2URI(destinationPath) {
 				// Sync local directory to R2 bucket
-				b := c.Bucket(pkg.RemoveR2URIPrefix(destinationPath))
-				b.SyncLocalToR2(sourcePath)
+				destURI := pkg.ParseR2URISafe(destinationPath)
+				b := c.Bucket(destURI.Bucket)
+				b.SyncLocalToR2WithPrefix(sourcePath, destURI.Path)
 			} else if pkg.IsR2URI(sourcePath) && !pkg.IsR2URI(destinationPath) {
 				// Sync R2 bucket to local directory
-				b := c.Bucket(pkg.RemoveR2URIPrefix(sourcePath))
-				b.SyncR2ToLocal(destinationPath)
+				sourceURI := pkg.ParseR2URISafe(sourcePath)
+				b := c.Bucket(sourceURI.Bucket)
+				b.SyncR2ToLocalWithPrefix(destinationPath, sourceURI.Path)
 			} else if pkg.IsR2URI(sourcePath) && pkg.IsR2URI(destinationPath) {
 				// Sync R2 bucket to R2 bucket
-				b := c.Bucket(pkg.RemoveR2URIPrefix(sourcePath))
-				destBucket := c.Bucket(pkg.RemoveR2URIPrefix(destinationPath))
-				b.SyncR2ToR2(destBucket)
+				sourceURI := pkg.ParseR2URISafe(sourcePath)
+				destURI := pkg.ParseR2URISafe(destinationPath)
+				b := c.Bucket(sourceURI.Bucket)
+				destBucket := c.Bucket(destURI.Bucket)
+				b.SyncR2ToR2WithPrefix(destBucket, sourceURI.Path, destURI.Path)
+			} else if !pkg.IsR2URI(sourcePath) && !pkg.IsR2URI(destinationPath) {
+				// Both paths are local - not supported
+				log.Fatal("Local-to-local sync is not supported. At least one path must be an R2 URI (r2://bucket/path).")
 			}
 		} else {
 			log.Fatal("Please provide both a source and destination path.")


### PR DESCRIPTION
## Summary
- Fixes sync command authentication errors caused by incorrect bucket name extraction
- Adds support for syncing to/from subdirectories in R2 buckets
- Implements security protection against path traversal attacks

## Problem
The sync command was failing with `SignatureDoesNotMatch` errors when attempting to sync files. Investigation revealed two issues:
1. Bucket names were being extracted with trailing slashes (e.g., "bucket/" instead of "bucket"), causing authentication failures
2. The sync command didn't support subdirectory paths like `r2://bucket/folder/`, attempting to sync entire buckets instead

## Solution
- Created `ParseR2URISafe()` to properly parse R2 URIs with or without paths
- Added prefix-aware sync methods that support subdirectory operations
- Implemented `GetObjectsWithPrefix()` for efficient server-side filtering
- Added path traversal protection to prevent malicious object names from escaping the destination directory

## Changes
- **pkg/helpers.go**: Added `ExtractBucketName()` and `ParseR2URISafe()` for proper URI parsing
- **pkg/bucket.go**: Added prefix-aware sync methods and `GetObjectsWithPrefix()`
- **cmd/sync.go**: Updated to use new parsing and call prefix-aware methods

## Testing
Tested the following scenarios:
- ✅ Sync local directory to R2 bucket root: `r2 sync ./local/ r2://bucket/`
- ✅ Sync local directory to R2 subdirectory: `r2 sync ./local/ r2://bucket/folder/`
- ✅ Sync from R2 subdirectory to local: `r2 sync r2://bucket/folder/ ./local/`
- ✅ Sync between R2 buckets with subdirectories
- ✅ Verified only files with matching prefixes are synced (not entire buckets)
- ✅ Tested with buckets containing >1000 objects (pagination still works)

## Compatibility
- Maintains backward compatibility - existing sync commands work unchanged
- Original sync methods delegate to new prefix-aware implementations with empty prefixes

## Security
- Implemented path traversal protection in `SyncR2ToLocalWithPrefix()` to prevent malicious object names from writing outside the destination directory