### PR TITLE
chore(dependabot): add commit-message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,12 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore"
+      prefix: "deps"
       include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore"
+      prefix: "deps"
       include: "scope"


### PR DESCRIPTION
Linear: [WWM-123](https://linear.app/atemp/issue/WWM-123/erdos-air2-add-commit-message-prefix-to-dependabotyml-for-release)

## Summary

Adds a `commit-message` block with `prefix: "chore"` and `include: "scope"` to every update entry in `.github/dependabot.yml`.

## Why

Without an explicit `commit-message` prefix, Dependabot PRs don't follow Conventional Commits. That means they are skipped by release-please and don't appear in the generated changelog. With this change, Dependabot PRs will be commit-formatted as `chore(deps): ...` / `chore(deps-dev): ...` and will be picked up by release-please.

Greptile flagged this as P2 on the originating Dependabot config PR (#25). This cleanup is independent of the Go 1.24 work tracked in WWM-122.

## Test plan
- [ ] Leave for bot review; verify next Dependabot PR uses `chore(deps): ...` prefix and appears under the release-please changelog.