### PR TITLE
chore: bump Go to 1.24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.19.5'
+          go-version: '>=1.24.0'
           cache: true
       - uses: anchore/sbom-action@v0
       - uses: goreleaser/goreleaser-action@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Repository Guidelines
 
-This repository hosts `r2`, a Go (1.22) CLI and library for Cloudflare R2 built on Cobra and the AWS S3 SDK. Use this guide to contribute changes consistently and safely.
+This repository hosts `r2`, a Go (1.24) CLI and library for Cloudflare R2 built on Cobra and the AWS S3 SDK. Use this guide to contribute changes consistently and safely.
 
 ## Project Structure & Module Organization
 - `cmd/`: Cobra commands (one file per subcommand, e.g. `cp.go`, `ls.go`, `sync.go`; root in `root.go`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ git push origin v0.1.0
 ### Key Dependencies
 - `github.com/spf13/cobra`: CLI framework
 - `github.com/aws/aws-sdk-go-v2`: AWS SDK for S3-compatible operations
-- Go 1.19+ required
+- Go 1.24+ required
 
 ### Command Pattern
 All CLI commands follow the same pattern:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/erdos-one/r2
 
-go 1.22
+go 1.24
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.31.2


### PR DESCRIPTION
## Summary

Pre-compat change for the AWS SDK v2 Dependabot bumps. All three open Dependabot PRs (#29, #32, #33) silently raise the `go` directive in `go.mod` from `1.22` to `1.24`, which Greptile flagged as P1 on #29 (risk of breaking CI on older toolchains). This PR lands the Go toolchain bump ahead of the SDK bumps so the Dependabot PRs merge cleanly.

Linear: [WWM-122](https://linear.app/atemp/issue/WWM-122/erdos-air2-verify-go-124-compatibility-before-merging-aws-sdk-prs)

## Changes

- `go.mod`: `go 1.22` → `go 1.24`
- `.github/workflows/release.yml`: `setup-go` version constraint `>=1.19.5` → `>=1.24.0` so the release pipeline resolves a toolchain that satisfies the new module minimum.
- `CLAUDE.md`: "Go 1.19+ required" → "Go 1.24+ required" (stale).
- `AGENTS.md`: "Go (1.22)" → "Go (1.24)" (stale sanity-check hit).

## Blocked Dependabot PRs

These depend on this PR landing first and should be merged in order afterwards:

- #29 — bumps `aws-sdk-go-v2/config`, `credentials`, core SDK to v1.41.5, etc.
- #32 — bumps `aws-sdk-go-v2/service/s3` to v1.99.0
- #33 — bumps `aws-sdk-go-v2/credentials` and related indirects

All three independently raise `go.mod`'s `go` directive to `1.24`; with that directive already set here, they become no-op on that line.

## Notes

- Go 1.24 (released Feb 2025) is available on `ubuntu-latest` runners used by the release workflow.
- No code changes — only toolchain/docs metadata.
- Do not merge the Dependabot PRs until this PR is reviewed and merged.

## Test plan

- [ ] CI green on this branch
- [ ] After merge, rebase Dependabot PRs #29, #32, #33 and merge in order
