### PR TITLE
[codex] add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.24.0'
+          cache: true
+      - name: Check gofmt
+        run: |
+          files="$(gofmt -l .)"
+          if [ -n "$files" ]; then
+            echo "$files"
+            exit 1
+          fi
+
+  vet:
+    name: Vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.24.0'
+          cache: true
+      - run: go vet ./...
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.24.0'
+          cache: true
+      - run: go test ./...
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.24.0'
+          cache: true
+      - run: go build ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - main
 
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '>=1.24.0'
+          go-version: '1.24'
           cache: true
       - name: Check gofmt
         run: |
@@ -31,6 +31,18 @@ jobs:
             exit 1
           fi
 
+  tidy:
+    name: Tidy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.24'
+          cache: true
+      - run: go mod tidy
+      - run: git diff --exit-code go.mod go.sum
+
   vet:
     name: Vet
     runs-on: ubuntu-latest
@@ -38,7 +50,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '>=1.24.0'
+          go-version: '1.24'
           cache: true
       - run: go vet ./...
 
@@ -49,7 +61,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '>=1.24.0'
+          go-version: '1.24'
           cache: true
       - run: go test ./...
 
@@ -60,6 +72,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '>=1.24.0'
+          go-version: '1.24'
           cache: true
       - run: go build ./...


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI with separate visible jobs for lint, typecheck, test, build, or equivalent repo checks where supported.
- Follow the Trellis-style split-check pattern so failures identify the failing category instead of collapsing into one opaque CI result.
- Include small baseline fixes where needed so the new CI starts from a passing state.

## Validation

- Ran `actionlint` across all new workflow files.
- Ran YAML parsing across all new workflow files.
- Ran repo-specific checks locally while wiring CI; see commit diff for the exact commands each workflow will enforce.
