### PR TITLE
Add Socket Tier 1 reachability workflow

### DIFF
--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -1,0 +1,37 @@
+name: Socket Security
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  socket:
+    name: Socket Tier 1 Reachability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Install Socket CLI
+        run: python -m pip install socketsecurity
+
+      - name: Run Socket scan
+        env:
+          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+        run: |
+          socketcli \
+            --target-path "$GITHUB_WORKSPACE" \
+            --scm github \
+            --pr-number "$PR_NUMBER"

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
+  issues: write
 
 jobs:
   socket:
@@ -29,6 +31,8 @@ jobs:
       - name: Run Socket scan
         env:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
         run: |
           socketcli \

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,0 +1,3 @@
+setup:
+  project: r2
+  config: gh


### PR DESCRIPTION
## Summary

- Adds a Socket Security GitHub Actions workflow for Tier 1 reachability scanning
- Runs Socket scans on pushes to main, pull requests to main, and manual dispatch
- Uses `SOCKET_SECURITY_API_KEY` from GitHub Actions secrets, synced from Doppler

Linear: WWM-144

## Validation

- Parsed `.github/workflows/socket.yml` as YAML locally
- Ran `git diff --check`
- Verified the workflow references `${{ secrets.SOCKET_SECURITY_API_KEY }}` and does not hardcode a token