### PR TITLE
[codex] stagger Dependabot updates to 1 PM Central

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "0 9 * * *"
+      cronjob: "0 13 * * *"
       timezone: "America/Chicago"
     open-pull-requests-limit: 2
     groups:
@@ -23,7 +23,7 @@ updates:
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "0 9 * * *"
+      cronjob: "0 13 * * *"
       timezone: "America/Chicago"
     open-pull-requests-limit: 2
     groups:


### PR DESCRIPTION
## Summary
- Update Dependabot to run Go module and GitHub Actions checks at 1:00 PM Central.
- Keep grouped minor/patch and major Dependabot PR behavior consistent with the existing config pattern.

## Validation
- Inspected the Dependabot config diff locally.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/erdos-ai/r2/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
