### PR TITLE
fix: rename Go module path to erdos-ai after org rename

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,7 @@ before:
     - go mod tidy
 builds:
   - ldflags:
-      - -s -w -X github.com/erdos-one/r2/cmd.version={{.Version}}
+      - -s -w -X github.com/erdos-ai/r2/cmd.version={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ R2 is a CLI and Go library for working with Cloudflare's R2 Storage service. It 
 go build -o r2 main.go
 
 # Build with version information
-go build -ldflags "-s -w -X github.com/erdos-one/r2/cmd.version=v1.0.0" -o r2 main.go
+go build -ldflags "-s -w -X github.com/erdos-ai/r2/cmd.version=v1.0.0" -o r2 main.go
 ```
 
 ### Installing Dependencies

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ The zero-dependency CLI is available for Linux and macOS and can be installed wi
 command:
 
 ```bash
-sh <(curl https://install.erdos.one/r2)
+sh <(curl -fsSL https://raw.githubusercontent.com/erdos-ai/r2/main/install.sh)
 ```
 
 ## Library
@@ -14,5 +14,5 @@ sh <(curl https://install.erdos.one/r2)
 The library is available as a Go module and can be installed with the following command:
 
 ```bash
-go get github.com/erdos-one/r2/pkg
+go get github.com/erdos-ai/r2/pkg
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/erdos-one/r2">
+  <a href="https://github.com/erdos-ai/r2">
     <img alt="R2 CLI" src="assets/bucket.svg" width="150"/>
   </a>
 </p>
@@ -9,8 +9,8 @@
 </h1>
 
 <p align="center">
-  <a href="https://github.com/erdos-one/r2/releases/latest" title="GitHub release">
-    <img src="https://img.shields.io/github/release/erdos-one/r2.svg">
+  <a href="https://github.com/erdos-ai/r2/releases/latest" title="GitHub release">
+    <img src="https://img.shields.io/github/release/erdos-ai/r2.svg">
   </a>
   <a href="https://opensource.org/licenses/Apache-2.0" title="License: Apache-2.0">
     <img src="https://img.shields.io/badge/License-Apache%202-blue.svg">
@@ -35,7 +35,7 @@ gap.
 To install the `r2` CLI, simply run the following command:
 
 ```bash
-go install github.com/erdos-one/r2@latest
+go install github.com/erdos-ai/r2@latest
 ```
 
 For more installation options, see [INSTALL.md](INSTALL.md).
@@ -97,7 +97,7 @@ For more usage information — including library usage — see [USAGE.md](USAGE.
 ## Progress
 
 We're working to implement all the functionality of the AWS CLI's s3 subcommand. As of
-[v0.1.0-alpha](https://github.com/erdos-one/r2/tree/v0.1.0-alpha), we have all the commands
+[v0.1.0-alpha](https://github.com/erdos-ai/r2/tree/v0.1.0-alpha), we have all the commands
 implemented, but not all the options. We're working on it, but if you'd like to lend a helping hand,
 we'd much appreciate your help!
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -123,7 +123,7 @@ echo "data" | r2 pipe r2://bucket/file.txt --quiet
 The `r2` library can be used to interact with R2 from within your Go application. All library code
 exists in the [pkg](pkg) directory and is well documented.
 
-Documentation may be found [here](https://pkg.go.dev/github.com/erdos-one/r2/pkg).
+Documentation may be found [here](https://pkg.go.dev/github.com/erdos-ai/r2/pkg).
 
 ### Example
 
@@ -133,7 +133,7 @@ Uploading a file to a bucket:
 package main
 
 import (
-  r2 "github.com/erdos-one/r2/pkg"
+  r2 "github.com/erdos-ai/r2/pkg"
 )
 
 func main() {

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/erdos-one/r2/pkg"
+	"github.com/erdos-ai/r2/pkg"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/ini.v1"

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/erdos-one/r2/pkg"
+	"github.com/erdos-ai/r2/pkg"
 )
 
 func TestGetConfig_EmptyFile(t *testing.T) {

--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"log"
 
-	"github.com/erdos-one/r2/pkg"
+	"github.com/erdos-ai/r2/pkg"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"log"
 
-	"github.com/erdos-one/r2/pkg"
+	"github.com/erdos-ai/r2/pkg"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/mb.go
+++ b/cmd/mb.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/erdos-one/r2/pkg"
+	"github.com/erdos-ai/r2/pkg"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/mv.go
+++ b/cmd/mv.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/erdos-one/r2/pkg"
+	"github.com/erdos-ai/r2/pkg"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/pipe.go
+++ b/cmd/pipe.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/erdos-one/r2/pkg"
+	"github.com/erdos-ai/r2/pkg"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/presign.go
+++ b/cmd/presign.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/erdos-one/r2/pkg"
+	"github.com/erdos-ai/r2/pkg"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/rb.go
+++ b/cmd/rb.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/erdos-one/r2/pkg"
+	"github.com/erdos-ai/r2/pkg"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"log"
 
-	"github.com/erdos-one/r2/pkg"
+	"github.com/erdos-ai/r2/pkg"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"log"
 
-	"github.com/erdos-one/r2/pkg"
+	"github.com/erdos-ai/r2/pkg"
 
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/erdos-one/r2
+module github.com/erdos-ai/r2
 
 go 1.24
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/erdos-one/r2/cmd"
+import "github.com/erdos-ai/r2/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## Summary

The org was renamed from `erdos-one` to `erdos-ai`. The repo and release artifacts had already moved (the `CHANGELOG.md` and generated `install.sh` use `erdos-ai`), but the Go module path and docs still referenced `erdos-one` — so `go install github.com/erdos-one/r2@latest` no longer worked. This updates everything to the new org.

## Changes

- **Go module path** (`go.mod`) renamed to `github.com/erdos-ai/r2`, with all internal imports updated (`main.go`, `cmd/*.go`).
- **Build config**: `.goreleaser.yaml` ldflags and the build command in `CLAUDE.md`.
- **Docs**: install command in `README.md`, badges/links, `go get` path and pkg.go.dev/example links in `INSTALL.md` / `USAGE.md`.
- **CLI installer**: the one-line `curl` installer in `INSTALL.md` pointed at `https://install.erdos.one/r2`, which no longer resolves. Repointed it at the GitHub-hosted script: `sh <(curl -fsSL https://raw.githubusercontent.com/erdos-ai/r2/main/install.sh)`.

## Notes

- `install.sh` was left unchanged — it's auto-generated by `scripts/make-install.sh`, which derives the org from the git remote and already produces `erdos-ai`.

## Verification

`go build ./...`, `go vet ./...`, and `go test ./...` all pass with the new module path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvesyMvDn9dysWQmsPeJiQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvesyMvDn9dysWQmsPeJiQ)_